### PR TITLE
PBC-4 gpio expander device I2C address fix

### DIFF
--- a/arch/arm/boot/dts/imx6dp-chargepoint-pbc.dts
+++ b/arch/arm/boot/dts/imx6dp-chargepoint-pbc.dts
@@ -354,7 +354,7 @@
 
         gpio-controller@77 { /* power module interface */
                 compatible = "nxp,pca9539";
-                reg = <0x74>;
+                reg = <0x77>;
                 gpio-controller;
                 #gpio-cells = <2>;
                 interrupt-parent = <&gpio1>;


### PR DESCRIPTION
Fix gpio expander i2C address to provide fan control.