### PR TITLE
wm8974 codec iMX machine driver port to 5.4 Kernel

### DIFF
--- a/sound/soc/fsl/imx-wm8974.c
+++ b/sound/soc/fsl/imx-wm8974.c
@@ -43,9 +43,9 @@ static int imx_wm8974_dai_init(struct snd_soc_pcm_runtime *rtd)
 	int ret;
 
 	ret = snd_soc_dai_set_sysclk(rtd->codec_dai, 0,
-				     data->clk_frequency, SND_SOC_CLOCK_IN);
+					data->clk_frequency, SND_SOC_CLOCK_IN);
 	if (ret) {
-                dev_err(dev, "could not set codec driver clock params\n");
+		dev_err(dev, "could not set codec driver clock params\n");
 		return ret;
 	}
 
@@ -107,12 +107,12 @@ static int imx_wm8974_probe(struct platform_device *pdev)
 	struct platform_device *ssi_pdev;
 	struct i2c_client *codec_dev;
 	struct imx_wm8974_data *data = NULL;
-        struct snd_soc_dai_link_component *comp;
+	struct snd_soc_dai_link_component *comp;
 	int ret;
 
 	ssi_np = of_parse_phandle(pdev->dev.of_node, "cpu-dai", 0);
 
-        if (strstr(ssi_np->name, "ssi")) {
+	if (strstr(ssi_np->name, "ssi")) {
 		ret = ssi_audmux_config(pdev); /* required for imx6 ssi */
 		if (ret) {
 			dev_err(&pdev->dev, "fail to configure ssi audmux\n");
@@ -133,7 +133,8 @@ static int imx_wm8974_probe(struct platform_device *pdev)
 		ret = -EPROBE_DEFER;
 		goto fail;
 	}
-        put_device(&ssi_pdev->dev);
+
+	put_device(&ssi_pdev->dev);
 
 	codec_dev = of_find_i2c_device_by_node(codec_np);
 	if (!codec_dev) {
@@ -147,11 +148,11 @@ static int imx_wm8974_probe(struct platform_device *pdev)
 		goto fail;
 	}
 
-        comp = devm_kzalloc(&pdev->dev, 3 * sizeof(*comp), GFP_KERNEL);
-        if (!comp) {
-                ret = -ENOMEM;
-                goto fail;
-        }
+	comp = devm_kzalloc(&pdev->dev, 3 * sizeof(*comp), GFP_KERNEL);
+	if (!comp) {
+		ret = -ENOMEM;
+		goto fail;
+	}
 
 	data->codec_clk = devm_clk_get(&codec_dev->dev, NULL);
 	if (IS_ERR(data->codec_clk)) {
@@ -161,13 +162,13 @@ static int imx_wm8974_probe(struct platform_device *pdev)
 
 	data->clk_frequency = clk_get_rate(data->codec_clk);
 
-        data->dai.cpus          = &comp[0];
-        data->dai.codecs        = &comp[1];
-        data->dai.platforms     = &comp[2];
+	data->dai.cpus          = &comp[0];
+	data->dai.codecs        = &comp[1];
+	data->dai.platforms     = &comp[2];
 
-        data->dai.num_cpus      = 1;
-        data->dai.num_codecs    = 1;
-        data->dai.num_platforms = 1;
+	data->dai.num_cpus      = 1;
+	data->dai.num_codecs    = 1;
+	data->dai.num_platforms = 1;
 
 	clk_prepare_enable(data->codec_clk);
 
@@ -180,7 +181,7 @@ static int imx_wm8974_probe(struct platform_device *pdev)
 	data->dai.platforms->of_node = ssi_np;
 	data->dai.init = &imx_wm8974_dai_init;
 	data->dai.dai_fmt = SND_SOC_DAIFMT_I2S | SND_SOC_DAIFMT_NB_NF |
-			    SND_SOC_DAIFMT_CBS_CFS;
+						SND_SOC_DAIFMT_CBS_CFS;
 
 	data->card.dev = &pdev->dev;
 	ret = snd_soc_of_parse_card_name(&data->card, "model");
@@ -201,7 +202,7 @@ static int imx_wm8974_probe(struct platform_device *pdev)
 	ret = devm_snd_soc_register_card(&pdev->dev, &data->card);
 	if (ret) {
 		dev_err(&pdev->dev, "snd_soc_register_card failed (%d)\n",
-                        ret);
+			ret);
 		goto fail;
 	}
 


### PR DESCRIPTION
This change migrate current wm8974 codec iMX machine driver to kernel version 5.4 base line.

This is part#2 of the original w8974 codec driver check, and didn't make first commit by mistake.