### PR TITLE
spidev: Added a new ti device to spidev

### DIFF
--- a/drivers/spi/spidev.c
+++ b/drivers/spi/spidev.c
@@ -665,6 +665,7 @@ static const struct of_device_id spidev_dt_ids[] = {
 	{ .compatible = "lwn,bk4" },
 	{ .compatible = "dh,dhcom-board" },
 	{ .compatible = "menlo,m53cpld" },
+	{ .compatible = "ti,ads114s0xb"},
 	{},
 };
 MODULE_DEVICE_TABLE(of, spidev_dt_ids);


### PR DESCRIPTION
As noted in the kernel patch acceptance for spidev, adding a proper device to
this list will ensure that when you create your device tree entry for the user
space device that it is done so in a way that names the device type which it is
connected.  This is needed since it is a non-kernel space driver.

- Added the ti part which is connected to the spi bus, that is going to be used
as a spidev device.

Signed-off-by: Trampus Richmond <trampus.richmond@chargepoint.com>