### PR TITLE
fix(sound): add support to wm8974 for kernel 6.1

### DIFF
--- a/sound/soc/fsl/Kconfig
+++ b/sound/soc/fsl/Kconfig
@@ -407,6 +407,20 @@ config SND_SOC_IMX6QDL_HDMI
 	  Say Y if you want to add support for SoC audio on an i.MX board with
 	  IMX6QDL HDMI.
 
+config SND_SOC_IMX_WM8974
+	tristate "SoC Audio support for i.MX boards with wm8974"
+	depends on OF && I2C
+	select SND_SOC_WM8974
+	select SND_SOC_IMX_PCM_DMA
+	select SND_SOC_IMX_AUDMUX
+	select SND_SOC_FSL_SSI
+	select SND_SOC_FSL_ESAI
+	select SND_SOC_FSL_SAI
+	select SND_KCTL_JACK
+	help
+	  Say Y if you want to add support for SoC audio on an i.MX board with
+	  a wm8974 mono codec.
+
 endif # SND_IMX_SOC
 
 endmenu

--- a/sound/soc/fsl/Makefile
+++ b/sound/soc/fsl/Makefile
@@ -29,6 +29,7 @@ snd-soc-fsl-xcvr-objs := fsl_xcvr.o fsl_xcvr_sysfs.o
 snd-soc-fsl-aud2htx-objs := fsl_aud2htx.o
 snd-soc-fsl-rpmsg-objs := fsl_rpmsg.o
 snd-soc-fsl-esai-client-objs := fsl_esai_client.o
+snd-soc-imx-wm8974-objs := imx-wm8974.o
 
 obj-$(CONFIG_SND_SOC_FSL_AUDMIX) += snd-soc-fsl-audmix.o
 obj-$(CONFIG_SND_SOC_FSL_ASOC_CARD) += snd-soc-fsl-asoc-card.o
@@ -48,6 +49,7 @@ obj-$(CONFIG_SND_SOC_FSL_XCVR) += snd-soc-fsl-xcvr.o
 obj-$(CONFIG_SND_SOC_FSL_AUD2HTX) += snd-soc-fsl-aud2htx.o
 obj-$(CONFIG_SND_SOC_FSL_RPMSG) += snd-soc-fsl-rpmsg.o
 obj-$(CONFIG_SND_SOC_FSL_ESAI_CLIENT) += snd-soc-fsl-esai-client.o
+obj-$(CONFIG_SND_SOC_IMX_WM8974) += snd-soc-imx-wm8974.o
 
 # MPC5200 Platform Support
 obj-$(CONFIG_SND_MPC52xx_DMA) += mpc5200_dma.o

--- a/sound/soc/fsl/imx-wm8974.c
+++ b/sound/soc/fsl/imx-wm8974.c
@@ -1,0 +1,261 @@
+// SPDX-License-Identifier: GPL-2.0+
+/*
+ * Copyright (C) 2013-2016 Freescale Semiconductor, Inc.
+ *
+ * Based on imx-sgtl5000.c
+ * Copyright (C) 2012 Freescale Semiconductor, Inc.
+ * Copyright (C) 2012 Linaro Ltd.
+ * Copyright 2017 NXP
+ *
+ * The code contained herein is licensed under the GNU General Public
+ * License. You may obtain a copy of the GNU General Public License
+ * Version 2 or later at the following locations:
+ *
+ * http://www.opensource.org/licenses/gpl-license.html
+ * http://www.gnu.org/copyleft/gpl.html
+ */
+
+#include <linux/module.h>
+#include <linux/of.h>
+#include <linux/of_platform.h>
+#include <linux/i2c.h>
+#include <linux/clk.h>
+#include <sound/soc.h>
+
+#include "../codecs/wm8974.h"
+#include "imx-audmux.h"
+
+#define DAI_NAME_SIZE	32
+
+struct imx_wm8974_data {
+	struct snd_soc_dai_link dai;
+	struct snd_soc_card card;
+	char codec_dai_name[DAI_NAME_SIZE];
+	char platform_name[DAI_NAME_SIZE];
+	struct clk *codec_clk;
+	unsigned int clk_frequency;
+};
+
+static int imx_wm8974_dai_init(struct snd_soc_pcm_runtime *rtd)
+{
+	struct imx_wm8974_data *data = snd_soc_card_get_drvdata(rtd->card);
+	struct device *dev = rtd->card->dev;
+	int ret;
+
+	ret = snd_soc_dai_set_sysclk(asoc_rtd_to_codec(rtd, 0), 0,
+					data->clk_frequency, SND_SOC_CLOCK_IN);
+	if (ret) {
+		dev_err(dev, "could not set codec driver clock params\n");
+		return ret;
+	}
+
+	return 0;
+}
+
+static const struct snd_soc_dapm_widget imx_wm8974_dapm_widgets[] = {
+	SND_SOC_DAPM_MIC("Mic Jack", NULL),
+	SND_SOC_DAPM_LINE("Line In Jack", NULL),
+	SND_SOC_DAPM_HP("Headphone Jack", NULL),
+	SND_SOC_DAPM_SPK("Line Out Jack", NULL),
+	SND_SOC_DAPM_SPK("Ext Spk", NULL),
+};
+
+static int ssi_audmux_config(struct platform_device *pdev)
+{
+	struct device_node *np = pdev->dev.of_node;
+	int int_port, ext_port;
+	int ret;
+
+	ret = of_property_read_u32(np, "mux-int-port", &int_port);
+	if (ret) {
+		dev_err(&pdev->dev, "mux-int-port missing or invalid\n");
+		return ret;
+	}
+	ret = of_property_read_u32(np, "mux-ext-port", &ext_port);
+	if (ret) {
+		dev_err(&pdev->dev, "mux-ext-port missing or invalid\n");
+		return ret;
+	}
+
+	/*
+	 * The port numbering in the hardware manual starts at 1, while
+	 * the audmux API expects it starts at 0.
+	 */
+	int_port--;
+	ext_port--;
+	ret = imx_audmux_v2_configure_port(ext_port,
+			IMX_AUDMUX_V2_PTCR_SYN |
+			IMX_AUDMUX_V2_PTCR_TFSEL(int_port) |
+			IMX_AUDMUX_V2_PTCR_TCSEL(int_port) |
+			IMX_AUDMUX_V2_PTCR_TFSDIR |
+			IMX_AUDMUX_V2_PTCR_TCLKDIR,
+			IMX_AUDMUX_V2_PDCR_RXDSEL(int_port));
+	if (ret) {
+		dev_err(&pdev->dev, "audmux internal port setup failed\n");
+		return ret;
+	}
+	ret = imx_audmux_v2_configure_port(int_port,
+			IMX_AUDMUX_V2_PTCR_SYN,
+			IMX_AUDMUX_V2_PDCR_RXDSEL(ext_port));
+	if (ret) {
+		dev_err(&pdev->dev, "audmux external port setup failed\n");
+		return ret;
+	}
+	return ret;
+}
+
+static int imx_wm8974_probe(struct platform_device *pdev)
+{
+	struct device_node *ssi_np, *codec_np;
+	struct platform_device *ssi_pdev;
+	struct i2c_client *codec_dev;
+	struct imx_wm8974_data *data = NULL;
+	struct snd_soc_dai_link_component *comp;
+	int ret;
+	pr_err("loading imx wm8974\n");
+
+
+	if (!pdev) {
+		pr_err("NULL PDEV\n");
+	}
+
+	ssi_np = of_parse_phandle(pdev->dev.of_node, "audio-cpu", 0);
+	if (strstr(ssi_np->name, "ssi")) {
+		ret = ssi_audmux_config(pdev); /* required for imx6 ssi */
+		if (ret) {
+			dev_err(&pdev->dev, "fail to configure ssi audmux\n");
+			goto fail;
+		}
+	}
+
+	codec_np = of_parse_phandle(pdev->dev.of_node, "audio-codec", 0);
+	if (!ssi_np || !codec_np) {
+		dev_err(&pdev->dev, "phandle missing or invalid\n");
+		ret = -EINVAL;
+		goto fail;
+	}
+
+	ssi_pdev = of_find_device_by_node(ssi_np);
+	if (!ssi_pdev) {
+		dev_err(&pdev->dev, "failed to find SSI platform device\n");
+		ret = -EPROBE_DEFER;
+		goto fail;
+	}
+
+	put_device(&ssi_pdev->dev);
+
+	codec_dev = of_find_i2c_device_by_node(codec_np);
+	if (!codec_dev) {
+		dev_err(&pdev->dev, "failed to find codec platform device\n");
+		return -EPROBE_DEFER;
+	}
+
+	data = devm_kzalloc(&pdev->dev, sizeof(*data), GFP_KERNEL);
+	if (!data) {
+		ret = -ENOMEM;
+		goto fail;
+	}
+
+	comp = devm_kzalloc(&pdev->dev, 3 * sizeof(*comp), GFP_KERNEL);
+	if (!comp) {
+		ret = -ENOMEM;
+		goto fail;
+	}
+
+	data->codec_clk = devm_clk_get(&codec_dev->dev, NULL);
+	if (IS_ERR(data->codec_clk)) {
+		ret = PTR_ERR(data->codec_clk);
+		goto fail;
+	}
+
+	data->clk_frequency = clk_get_rate(data->codec_clk);
+
+	data->dai.cpus          = &comp[0];
+	data->dai.codecs        = &comp[1];
+	data->dai.platforms     = &comp[2];
+
+	data->dai.num_cpus      = 1;
+	data->dai.num_codecs    = 1;
+	data->dai.num_platforms = 1;
+
+	clk_prepare_enable(data->codec_clk);
+
+	data->dai.name = "HiFi";
+	data->dai.stream_name = "HiFi";
+	data->dai.codecs->dai_name = "wm8974-hifi";
+	data->dai.codecs->of_node = codec_np;
+	data->dai.cpus->of_node = ssi_np;
+	data->dai.cpus->dai_name = dev_name(&ssi_pdev->dev);
+	data->dai.platforms->of_node = ssi_np;
+	data->dai.init = &imx_wm8974_dai_init;
+	data->dai.dai_fmt = SND_SOC_DAIFMT_I2S | SND_SOC_DAIFMT_NB_NF |
+						SND_SOC_DAIFMT_CBS_CFS;
+
+	data->card.dev = &pdev->dev;
+	ret = snd_soc_of_parse_card_name(&data->card, "model");
+	if (ret)
+		goto fail;
+	ret = snd_soc_of_parse_audio_routing(&data->card, "audio-routing");
+	if (ret)
+		goto fail;
+	data->card.num_links = 1;
+	data->card.owner = THIS_MODULE;
+	data->card.dai_link = &data->dai;
+	data->card.dapm_widgets = imx_wm8974_dapm_widgets;
+	data->card.num_dapm_widgets = ARRAY_SIZE(imx_wm8974_dapm_widgets);
+
+	platform_set_drvdata(pdev, &data->card);
+	snd_soc_card_set_drvdata(&data->card, data);
+
+	ret = devm_snd_soc_register_card(&pdev->dev, &data->card);
+	if (ret) {
+		dev_err(&pdev->dev, "snd_soc_register_card failed (%d)\n",
+			ret);
+		goto fail;
+	}
+
+	of_node_put(ssi_np);
+	of_node_put(codec_np);
+
+	return 0;
+
+fail:
+	if (data && !IS_ERR(data->codec_clk))
+		clk_put(data->codec_clk);
+	of_node_put(ssi_np);
+	of_node_put(codec_np);
+
+	return ret;
+}
+
+static int imx_wm8974_remove(struct platform_device *pdev)
+{
+	struct snd_soc_card *card = platform_get_drvdata(pdev);
+	struct imx_wm8974_data *data = snd_soc_card_get_drvdata(card);
+
+	clk_put(data->codec_clk);
+
+	return 0;
+}
+
+static const struct of_device_id imx_wm8974_dt_ids[] = {
+	{ .compatible = "fsl,imx-audio-wm8974", },
+	{ /* sentinel */ }
+};
+MODULE_DEVICE_TABLE(of, imx_wm8974_dt_ids);
+
+static struct platform_driver imx_wm8974_driver = {
+	.driver = {
+		.name = "imx-wm8974",
+		.pm = &snd_soc_pm_ops,
+		.of_match_table = imx_wm8974_dt_ids,
+	},
+	.probe = imx_wm8974_probe,
+	.remove = imx_wm8974_remove,
+};
+module_platform_driver(imx_wm8974_driver);
+
+MODULE_AUTHOR("ChargePoint Inc.");
+MODULE_DESCRIPTION("Freescale i.MX wm8974 ASoC machine driver");
+MODULE_LICENSE("GPL v2");
+MODULE_ALIAS("platform:imx-wm8974");


### PR DESCRIPTION
Reapplied patches from old kernel and edited them to work for 6.1 goes with this:

https://github.com/ChargePoint/emb-platform/tree/jamesickes-cpi/PLAT-9104

[PLAT-9104]

[PLAT-9104]: https://chargepoint.atlassian.net/browse/PLAT-9104?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ