### PR TITLE
Cherry-pick fix for iio adc imx8qxp

### DIFF
--- a/drivers/iio/adc/imx8qxp-adc.c
+++ b/drivers/iio/adc/imx8qxp-adc.c
@@ -38,8 +38,8 @@
 #define IMX8QXP_ADR_ADC_FCTRL		0x30
 #define IMX8QXP_ADR_ADC_SWTRIG		0x34
 #define IMX8QXP_ADR_ADC_TCTRL(tid)	(0xc0 + (tid) * 4)
-#define IMX8QXP_ADR_ADC_CMDH(cid)	(0x100 + (cid) * 8)
-#define IMX8QXP_ADR_ADC_CMDL(cid)	(0x104 + (cid) * 8)
+#define IMX8QXP_ADR_ADC_CMDL(cid)	(0x100 + (cid) * 8)
+#define IMX8QXP_ADR_ADC_CMDH(cid)	(0x104 + (cid) * 8)
 #define IMX8QXP_ADR_ADC_RESFIFO		0x300
 #define IMX8QXP_ADR_ADC_TST		0xffc
 


### PR DESCRIPTION
This cherry-picks the register address fix for the imx8qxp ADC driver from the lf-6.6.y branch.
Without this fix, the ADC measurements are incorrectly written from the ADC on the lf-6.1.y branch.

Fixes [PLAT-13354]

[PLAT-13354]: https://chargepoint.atlassian.net/browse/PLAT-13354?atlOrigin=eyJpIjoiOWEzM2YzMWE3NDBlNGUxOGJiZmUxZjgyOTM5N2JmZDMiLCJwIjoiaiJ9