### PR TITLE
Revert "Bluetooth: Always request for user confirmation for Just Works"

### DIFF
--- a/net/bluetooth/smp.c
+++ b/net/bluetooth/smp.c
@@ -853,7 +853,7 @@ static int tk_request(struct l2cap_conn *conn, u8 remote_oob, u8 auth,
 	struct l2cap_chan *chan = conn->smp;
 	struct smp_chan *smp = chan->data;
 	u32 passkey = 0;
-	int ret;
+	int ret = 0;
 
 	/* Initialize key for JUST WORKS */
 	memset(smp->tk, 0, sizeof(smp->tk));
@@ -883,16 +883,9 @@ static int tk_request(struct l2cap_conn *conn, u8 remote_oob, u8 auth,
 	    hcon->io_capability == HCI_IO_NO_INPUT_OUTPUT)
 		smp->method = JUST_WORKS;
 
-	/* If Just Works, Continue with Zero TK and ask user-space for
-	 * confirmation */
+	/* If Just Works, Continue with Zero TK */
 	if (smp->method == JUST_WORKS) {
-		ret = mgmt_user_confirm_request(hcon->hdev, &hcon->dst,
-						hcon->type,
-						hcon->dst_type,
-						passkey, 1);
-		if (ret)
-			return ret;
-		set_bit(SMP_FLAG_WAIT_USER, &smp->flags);
+		set_bit(SMP_FLAG_TK_VALID, &smp->flags);
 		return 0;
 	}
 


### PR DESCRIPTION
This reverts commit 92516cd97fd4d8ad5b1421a0d51771044f453a5f.

This is needed to allow repairing of previously paired Bluetooth devices. The MGMT_EV_USER_CONFIRM_REQUEST to the user-space daemon results in an MGMT_OP_USER_CONFIRM_NEG_REPLY back to the kernel, resulting in an authentication failure.